### PR TITLE
fix: use environment variable instead of --extends flag for semantic-release

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -90,7 +90,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
         run: |
           # Run semantic-release with pre-release config
-          npx semantic-release --extends .releaserc.prerelease.json
+          SEMANTIC_RELEASE_CONFIG=.releaserc.prerelease.json npx semantic-release
 
       - name: Security Audit
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
           EOF
 
           # Run semantic-release with stable config
-          npx semantic-release --extends .releaserc.stable.json
+          SEMANTIC_RELEASE_CONFIG=.releaserc.stable.json npx semantic-release
 
       - name: Create PR to merge changelog to main
         if: steps.release.outputs.new_release_published == 'true'


### PR DESCRIPTION

The --extends flag expects an npm package name, not a file path. Using SEMANTIC_RELEASE_CONFIG environment variable correctly specifies the configuration file path.

This fixes the MODULE_NOT_FOUND error in both:
- prerelease workflow (.releaserc.prerelease.json)
- release workflow (.releaserc.stable.json)