### PR TITLE
fix: simplify semantic-release commit messages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
                   "assets": [
                     "CHANGELOG.md"
                   ],
-                  "message": "chore(release): \${nextRelease.version} [skip ci]\\n\\n\${nextRelease.notes}"
+                  "message": "chore(release): \${nextRelease.version} [skip ci]"
                 }
               ]
             ]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -38,7 +38,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ]
   ]

--- a/.releaserc.prerelease.json
+++ b/.releaserc.prerelease.json
@@ -37,7 +37,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ]
   ]


### PR DESCRIPTION
Remove release notes from commit messages to prevent commitlint failures.
The commit messages now only contain 'chore(release): X.Y.Z [skip ci]'
without the full changelog content.

This fixes the 'body-max-line-length' commitlint error that occurs when
BREAKING CHANGES sections contain long lines. The changelog content is
already written to CHANGELOG.md and GitHub releases, so there's no need
to duplicate it in the commit message.