### PR TITLE
fix: get version info from tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,15 @@ jobs:
           if [ $EXIT_CODE -eq 0 ]; then
             echo "new_release_published=true" >> "$GITHUB_OUTPUT"
             echo "Setting new_release_published=true"
+            
+            # Get the latest tag created by semantic-release
+            git fetch --tags
+            LATEST_TAG=$(git describe --tags --abbrev=0)
+            VERSION=$(echo $LATEST_TAG | sed 's/^v//')  # Remove 'v' prefix if present
+            
+            echo "new_release_version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "new_release_git_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+            echo "Found release tag: $LATEST_TAG (version: $VERSION)"
           else
             echo "new_release_published=false" >> "$GITHUB_OUTPUT"
             echo "Setting new_release_published=false"
@@ -138,18 +147,18 @@ jobs:
 
           # Check if CHANGELOG.md was created/updated
           if [ -f CHANGELOG.md ]; then
-            # Get current file SHA from release branch (if it exists)
-            SHA=$(gh api repos/:owner/:repo/contents/CHANGELOG.md --jq .sha --field ref="$BRANCH_NAME" 2>/dev/null || echo "")
-            
             # Get file content (base64 encoded)
             CONTENT=$(base64 -w 0 CHANGELOG.md)
             
             # Create conventional commit message
             COMMIT_MESSAGE="chore(release): update changelog for v${VERSION}"
             
-            # Prepare API call
-            if [ -n "$SHA" ]; then
-              # File exists, update it
+            echo "Attempting to commit changelog to $BRANCH_NAME branch..."
+            
+            # Try to get current file SHA from release branch
+            if SHA=$(gh api repos/:owner/:repo/contents/CHANGELOG.md --jq .sha --field ref="$BRANCH_NAME" 2>/dev/null); then
+              # File exists on release branch, update it
+              echo "File exists on $BRANCH_NAME, updating..."
               gh api --method PUT repos/:owner/:repo/contents/CHANGELOG.md \
                 --field message="$COMMIT_MESSAGE" \
                 --field content="$CONTENT" \
@@ -157,7 +166,8 @@ jobs:
                 --field sha="$SHA"
               echo "✅ Updated CHANGELOG.md on ${BRANCH_NAME} branch via API (GPG signed)"
             else
-              # File doesn't exist, create it
+              # File doesn't exist on release branch, create it
+              echo "File doesn't exist on $BRANCH_NAME, creating..."
               gh api --method PUT repos/:owner/:repo/contents/CHANGELOG.md \
                 --field message="$COMMIT_MESSAGE" \
                 --field content="$CONTENT" \


### PR DESCRIPTION
Fix version extraction to use latest git tag created by semantic-release
