### PR TITLE
fix: trigger CI checks on PRs created by GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -15,11 +18,13 @@ jobs:
   lint-commits:
     name: Lint Commits
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # For pull_request_target, we need to checkout the PR head
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Validate commits
         uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
Fixes the issue where changelog PRs created by the release workflow don't trigger CI checks.

Adds `pull_request_target` trigger to handle PRs created by GitHub Actions.