### PR TITLE
feat: add hotfix release workflow support

### DIFF
--- a/.github/configs/releaserc.prerelease.json
+++ b/.github/configs/releaserc.prerelease.json
@@ -1,0 +1,35 @@
+{
+  "branches": [
+    "release",
+    { "name": "hotfix/*", "prerelease": "development-hotfix" },
+    { "name": "main", "prerelease": "development" }
+  ],
+  "plugins": [
+    "semantic-release-unsquash",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": true,
+        "tarballDir": "dist"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "dist/*.tgz",
+            "label": "Package tarball"
+          }
+        ],
+        "addReleases": "bottom"
+      }
+    ]
+  ]
+}

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,155 @@
+name: Hotfix Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  security-check:
+    name: Security Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate workflow trigger
+        run: |
+          echo "🔒 Security Check: Validating workflow trigger"
+
+          # Ensure it's workflow_dispatch
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            echo "❌ Only workflow_dispatch is allowed for hotfix workflow"
+            exit 1
+          fi
+
+          # Ensure we're on a hotfix branch
+          if [[ ! "${{ github.ref }}" =~ ^refs/heads/hotfix/.+ ]]; then
+            echo "❌ Workflow dispatch only allowed from hotfix/* branches"
+            exit 1
+          fi
+
+          echo "✅ Security check passed for hotfix branch: ${{ github.ref }}"
+
+      - name: Create audit log
+        run: |
+          mkdir -p audit-logs
+          cat > audit-logs/attempt-$(date +%Y%m%d-%H%M%S).json << EOF
+          {
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "actor": "${{ github.actor }}",
+            "event": "${{ github.event_name }}",
+            "branch": "${{ github.ref }}",
+            "commit": "${{ github.sha }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "type": "hotfix"
+          }
+          EOF
+
+      - name: Upload audit log
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-audit-${{ github.run_id }}
+          path: audit-logs/
+          retention-days: 90
+
+  publish-hotfix:
+    needs: security-check
+    name: Publish Hotfix NPM Package
+    runs-on: ubuntu-latest
+    environment: production # Requires 2 approvals
+    outputs:
+      release_created: ${{ steps.release.outputs.new_release_published }}
+      tag_name: ${{ steps.release.outputs.new_release_git_tag }}
+      version: ${{ steps.release.outputs.new_release_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Audit signatures
+        run: npm audit signatures
+
+      - name: Create Hotfix Release
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+        run: |
+          echo "🔥 Creating hotfix release after approvals"
+          echo "📦 This will create version, tag, and publish to npm"
+          echo "ℹ️  Hotfix releases do not update changelog or create PRs"
+
+          # Run semantic-release and capture outputs
+          npx semantic-release > release-output.txt 2>&1
+          EXIT_CODE=$?
+
+          echo "Semantic-release exit code: $EXIT_CODE"
+          echo "Semantic-release output:"
+          cat release-output.txt
+
+          # Always set the output for debugging
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "new_release_published=true" >> "$GITHUB_OUTPUT"
+            echo "Setting new_release_published=true"
+            
+            # Get the latest tag created by semantic-release
+            git fetch --tags
+            LATEST_TAG=$(git describe --tags --abbrev=0)
+            VERSION=$(echo $LATEST_TAG | sed 's/^v//')  # Remove 'v' prefix if present
+            
+            echo "new_release_version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "new_release_git_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+            echo "Found release tag: $LATEST_TAG (version: $VERSION)"
+          else
+            echo "new_release_published=false" >> "$GITHUB_OUTPUT"
+            echo "Setting new_release_published=false"
+          fi
+
+  security-audit:
+    name: Post-Release Security Audit
+    needs: [publish-hotfix]
+    if: always() && needs.publish-hotfix.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.publish-hotfix.outputs.tag_name }}
+
+      - name: Audit Hotfix Release
+        run: |
+          echo "🔥 Hotfix Release Audit Log"
+          echo "=============================="
+          echo "Release Tag: ${{ needs.publish-hotfix.outputs.tag_name }}"
+          echo "Version: ${{ needs.publish-hotfix.outputs.version }}"
+          echo "Released by: ${{ github.actor }}"
+          echo "Release Time: $(date -u)"
+          echo "Commit SHA: ${{ github.sha }}"
+          echo "Release Type: HOTFIX"
+
+      - name: Verify NPM Package
+        run: |
+          sleep 30
+          npm view @wormhole-labs/dev-config@${{ needs.publish-hotfix.outputs.version }} version

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,6 +3,7 @@ name: Pre-release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -18,7 +19,7 @@ jobs:
       - name: Validate workflow trigger
         run: |
           echo "🔒 Security Check: Validating workflow trigger"
-          ALLOWED_EVENTS="push"
+          ALLOWED_EVENTS="push workflow_dispatch"
           if [[ ! "$ALLOWED_EVENTS" =~ "${{ github.event_name }}" ]]; then
             echo "❌ Unauthorized workflow trigger: ${{ github.event_name }}"
             exit 1
@@ -26,10 +27,21 @@ jobs:
 
       - name: Validate branch
         run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "❌ Pre-releases only allowed from main branch"
+          # For push events, must be main branch
+          if [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "❌ Push events only allowed from main branch"
             exit 1
           fi
+
+          # For workflow_dispatch, only allow hotfix/* branches
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ ! "${{ github.ref }}" =~ ^refs/heads/hotfix/.+ ]]; then
+              echo "❌ Manual dispatch only allowed from hotfix/* branches"
+              exit 1
+            fi
+          fi
+
+          echo "✅ Branch validation passed for: ${{ github.ref }}"
 
       - name: Create audit log
         run: |
@@ -82,6 +94,13 @@ jobs:
 
       - name: Audit signatures
         run: npm audit signatures
+
+      - name: Setup hotfix prerelease config
+        if: ${{ github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/hotfix/') }}
+        run: |
+          echo "📝 Setting up prerelease configuration for hotfix branch"
+          cp .github/configs/releaserc.prerelease.json .releaserc.json
+          echo "✅ Prerelease config applied for hotfix branch"
 
       - name: Create Pre-release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,9 @@
 {
-  "branches": ["release", { "name": "main", "prerelease": "development" }],
+  "branches": [
+    "release",
+    "hotfix/*",
+    { "name": "main", "prerelease": "development" }
+  ],
   "plugins": [
     "semantic-release-unsquash",
     [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+}


### PR DESCRIPTION
## Summary
Add hotfix release workflow for emergency patches with manual dispatch on `hotfix/*` branches.

## Changes
- **New hotfix workflow**: Manual release without changelog/PR steps
- **Enhanced prerelease**: Supports manual dispatch from hotfix branches  
- **Config**: Added `.github/configs/releaserc.prerelease.json` for hotfix prereleases